### PR TITLE
#93 Mini update of RealTimeMultiThreadScheduler

### DIFF
--- a/src/main/java/sima/core/scheduler/multithread/RealTimeMultiThreadScheduler.java
+++ b/src/main/java/sima/core/scheduler/multithread/RealTimeMultiThreadScheduler.java
@@ -210,7 +210,12 @@ public class RealTimeMultiThreadScheduler extends MultiThreadScheduler {
             if (RealTimeMultiThreadScheduler.this.executorThreadList.isEmpty()) {
                 synchronized (RealTimeMultiThreadScheduler.this) {
                     if (RealTimeMultiThreadScheduler.this.isStarted) {
-                        RealTimeMultiThreadScheduler.this.updateSchedulerWatcherOnNoExecutableToExecute();
+                        if (RealTimeMultiThreadScheduler.this.getCurrentTime()
+                                >= RealTimeMultiThreadScheduler.this.endSimulation) {
+                            RealTimeMultiThreadScheduler.this.updateSchedulerWatcherOnSimulationEndTimeReach();
+                        } else {
+                            RealTimeMultiThreadScheduler.this.updateSchedulerWatcherOnNoExecutableToExecute();
+                        }
                         RealTimeMultiThreadScheduler.this.kill();
                     } // Else the Scheduler has already be killed.
                 }


### PR DESCRIPTION
- Verify now if the END_SIMULATION is reach when there is no executable to execute
- It is impossible to schedule a Executable after the end time -> END_SIMULATION NEVER PASS and the Scheduler always stop at a moment